### PR TITLE
fix: remove the delegation.address in favor of pk address lookup

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -119,14 +119,14 @@ const docTemplate = `{
         },
         "/v1/staker/delegation/check": {
             "get": {
-                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot only)\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
+                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
                 "produces": [
                     "application/json"
                 ],
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Staker BTC address in Taproot format",
+                        "description": "Staker BTC address in Taproot/Native Segwit format",
                         "name": "address",
                         "in": "query",
                         "required": true

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -111,14 +111,14 @@
         },
         "/v1/staker/delegation/check": {
             "get": {
-                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot only)\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
+                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
                 "produces": [
                     "application/json"
                 ],
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Staker BTC address in Taproot format",
+                        "description": "Staker BTC address in Taproot/Native Segwit format",
                         "name": "address",
                         "in": "query",
                         "required": true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -307,11 +307,11 @@ paths:
   /v1/staker/delegation/check:
     get:
       description: |-
-        Check if a staker has an active delegation by the staker BTC address (Taproot only)
+        Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)
         Optionally, you can provide a timeframe to check if the delegation is active within the provided timeframe
         The available timeframe is "today" which checks after UTC 12AM of the current day
       parameters:
-      - description: Staker BTC address in Taproot format
+      - description: Staker BTC address in Taproot/Native Segwit format
         in: query
         name: address
         required: true

--- a/internal/db/delegation.go
+++ b/internal/db/delegation.go
@@ -16,7 +16,7 @@ import (
 func (db *Database) SaveActiveStakingDelegation(
 	ctx context.Context, stakingTxHashHex, stakerPkHex, fpPkHex string,
 	stakingTxHex string, amount, startHeight, timelock, outputIndex uint64,
-	startTimestamp int64, isOverflow bool, stakerTaprootAddress string,
+	startTimestamp int64, isOverflow bool,
 ) error {
 	client := db.Client.Database(db.DbName).Collection(model.DelegationCollection)
 	document := model.DelegationDocument{
@@ -33,9 +33,6 @@ func (db *Database) SaveActiveStakingDelegation(
 			TimeLock:       timelock,
 		},
 		IsOverflow: isOverflow,
-		StakerBtcAddress: &model.StakerBtcAddress{
-			TaprootAddress: stakerTaprootAddress,
-		},
 	}
 	_, err := client.InsertOne(ctx, document)
 	if err != nil {
@@ -56,14 +53,14 @@ func (db *Database) SaveActiveStakingDelegation(
 	return nil
 }
 
-// CheckDelegationExistByStakerTaprootAddress checks if a staker has any
-// delegation in the specified states by the staker's BTC address in taproot format.
-func (db *Database) CheckDelegationExistByStakerTaprootAddress(
-	ctx context.Context, address string, extraFilter *DelegationFilter,
+// CheckDelegationExistByStakerPk checks if a staker has any
+// delegation in the specified states by the staker's public key
+func (db *Database) CheckDelegationExistByStakerPk(
+	ctx context.Context, stakerPk string, extraFilter *DelegationFilter,
 ) (bool, error) {
 	client := db.Client.Database(db.DbName).Collection(model.DelegationCollection)
 	filter := buildAdditionalDelegationFilter(
-		bson.M{"staker_btc_address.taproot_address": address}, extraFilter,
+		bson.M{"staker_pk_hex": stakerPk}, extraFilter,
 	)
 	var delegation model.DelegationDocument
 	err := client.FindOne(ctx, filter).Decode(&delegation)

--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -12,7 +12,7 @@ type DBClient interface {
 	SaveActiveStakingDelegation(
 		ctx context.Context, stakingTxHashHex, stakerPkHex, fpPkHex string,
 		stakingTxHex string, amount, startHeight, timelock, outputIndex uint64,
-		startTimestamp int64, isOverflow bool, stakerTaprootAddress string,
+		startTimestamp int64, isOverflow bool,
 	) error
 	// FindDelegationsByStakerPk finds all delegations by the staker's public key.
 	// The extraFilter parameter can be used to filter the results by the delegation's
@@ -74,7 +74,7 @@ type DBClient interface {
 		ctx context.Context, height uint64, confirmedTvl uint64, unconfirmedTvl uint64,
 	) error
 	GetLatestBtcInfo(ctx context.Context) (*model.BtcInfo, error)
-	CheckDelegationExistByStakerTaprootAddress(
+	CheckDelegationExistByStakerPk(
 		ctx context.Context, address string, extraFilter *DelegationFilter,
 	) (bool, error)
 	// InsertPkAddressMappings inserts the btc public key and

--- a/internal/db/model/delegation.go
+++ b/internal/db/model/delegation.go
@@ -12,11 +12,6 @@ type TimelockTransaction struct {
 	TimeLock       uint64 `bson:"timelock"`
 }
 
-// The available addresses that can be derived from the given StakerPkHex
-type StakerBtcAddress struct {
-	TaprootAddress string `bson:"taproot_address"`
-}
-
 type DelegationDocument struct {
 	StakingTxHashHex      string                `bson:"_id"` // Primary key
 	StakerPkHex           string                `bson:"staker_pk_hex"`
@@ -26,7 +21,6 @@ type DelegationDocument struct {
 	StakingTx             *TimelockTransaction  `bson:"staking_tx"` // Always exist
 	UnbondingTx           *TimelockTransaction  `bson:"unbonding_tx,omitempty"`
 	IsOverflow            bool                  `bson:"is_overflow"`
-	StakerBtcAddress      *StakerBtcAddress     `bson:"staker_btc_address,omitempty"`
 }
 
 type DelegationByStakerPagination struct {

--- a/internal/services/delegation.go
+++ b/internal/services/delegation.go
@@ -93,16 +93,9 @@ func (s *Services) SaveActiveStakingDelegation(
 	value, startHeight uint64, stakingTimestamp int64, timeLock, stakingOutputIndex uint64,
 	stakingTxHex string, isOverflow bool,
 ) *types.Error {
-	addresses, err := utils.DeriveAddressesFromNoCoordPk(stakerPkHex, s.cfg.Server.BTCNetParam)
-	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("Failed to get taproot address from staker pk")
-		return types.NewErrorWithMsg(
-			http.StatusBadRequest, types.BadRequest, "failed to get taproot address from staker pk",
-		)
-	}
-	err = s.DbClient.SaveActiveStakingDelegation(
+	err := s.DbClient.SaveActiveStakingDelegation(
 		ctx, txHashHex, stakerPkHex, finalityProviderPkHex, stakingTxHex,
-		value, startHeight, timeLock, stakingOutputIndex, stakingTimestamp, isOverflow, addresses.Taproot,
+		value, startHeight, timeLock, stakingOutputIndex, stakingTimestamp, isOverflow,
 	)
 	if err != nil {
 		if ok := db.IsDuplicateKeyError(err); ok {
@@ -144,15 +137,15 @@ func (s *Services) GetDelegation(ctx context.Context, txHashHex string) (*model.
 	return delegation, nil
 }
 
-func (s *Services) CheckStakerHasActiveDelegationByAddress(
-	ctx context.Context, btcAddress string, afterTimestamp int64,
+func (s *Services) CheckStakerHasActiveDelegationByPk(
+	ctx context.Context, stakerPk string, afterTimestamp int64,
 ) (bool, *types.Error) {
 	filter := &db.DelegationFilter{
 		States:         []types.DelegationState{types.Active},
 		AfterTimestamp: afterTimestamp,
 	}
-	hasDelegation, err := s.DbClient.CheckDelegationExistByStakerTaprootAddress(
-		ctx, btcAddress, filter,
+	hasDelegation, err := s.DbClient.CheckDelegationExistByStakerPk(
+		ctx, stakerPk, filter,
 	)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Failed to check if staker has active delegation")

--- a/tests/mocks/mock_db_client.go
+++ b/tests/mocks/mock_db_client.go
@@ -18,12 +18,12 @@ type DBClient struct {
 	mock.Mock
 }
 
-// CheckDelegationExistByStakerTaprootAddress provides a mock function with given fields: ctx, address, extraFilter
-func (_m *DBClient) CheckDelegationExistByStakerTaprootAddress(ctx context.Context, address string, extraFilter *db.DelegationFilter) (bool, error) {
+// CheckDelegationExistByStakerPk provides a mock function with given fields: ctx, address, extraFilter
+func (_m *DBClient) CheckDelegationExistByStakerPk(ctx context.Context, address string, extraFilter *db.DelegationFilter) (bool, error) {
 	ret := _m.Called(ctx, address, extraFilter)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CheckDelegationExistByStakerTaprootAddress")
+		panic("no return value specified for CheckDelegationExistByStakerPk")
 	}
 
 	var r0 bool
@@ -514,17 +514,17 @@ func (_m *DBClient) Ping(ctx context.Context) error {
 	return r0
 }
 
-// SaveActiveStakingDelegation provides a mock function with given fields: ctx, stakingTxHashHex, stakerPkHex, fpPkHex, stakingTxHex, amount, startHeight, timelock, outputIndex, startTimestamp, isOverflow, stakerTaprootAddress
-func (_m *DBClient) SaveActiveStakingDelegation(ctx context.Context, stakingTxHashHex string, stakerPkHex string, fpPkHex string, stakingTxHex string, amount uint64, startHeight uint64, timelock uint64, outputIndex uint64, startTimestamp int64, isOverflow bool, stakerTaprootAddress string) error {
-	ret := _m.Called(ctx, stakingTxHashHex, stakerPkHex, fpPkHex, stakingTxHex, amount, startHeight, timelock, outputIndex, startTimestamp, isOverflow, stakerTaprootAddress)
+// SaveActiveStakingDelegation provides a mock function with given fields: ctx, stakingTxHashHex, stakerPkHex, fpPkHex, stakingTxHex, amount, startHeight, timelock, outputIndex, startTimestamp, isOverflow
+func (_m *DBClient) SaveActiveStakingDelegation(ctx context.Context, stakingTxHashHex string, stakerPkHex string, fpPkHex string, stakingTxHex string, amount uint64, startHeight uint64, timelock uint64, outputIndex uint64, startTimestamp int64, isOverflow bool) error {
+	ret := _m.Called(ctx, stakingTxHashHex, stakerPkHex, fpPkHex, stakingTxHex, amount, startHeight, timelock, outputIndex, startTimestamp, isOverflow)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveActiveStakingDelegation")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, uint64, uint64, uint64, uint64, int64, bool, string) error); ok {
-		r0 = rf(ctx, stakingTxHashHex, stakerPkHex, fpPkHex, stakingTxHex, amount, startHeight, timelock, outputIndex, startTimestamp, isOverflow, stakerTaprootAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, uint64, uint64, uint64, uint64, int64, bool) error); ok {
+		r0 = rf(ctx, stakingTxHashHex, stakerPkHex, fpPkHex, stakingTxHex, amount, startHeight, timelock, outputIndex, startTimestamp, isOverflow)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Note this PR is not to make the Cryptopedia from OKX to work. But serve the purpose of clean up the data and calling method so that when the requirements of Cryptopedia is clear to me, it will be a much smaller and quicker change to do.