### PR TITLE
feat: support delegation allow list

### DIFF
--- a/cmd/staking-api-service/cli/root.go
+++ b/cmd/staking-api-service/cli/root.go
@@ -9,15 +9,17 @@ import (
 )
 
 const (
-	defaultConfigFileName            = "config.yml"
-	defaultGlobalParamsFileName      = "global_params.json"
-	defaultFinalityProvidersFileName = "finality_providers.json"
+	defaultConfigFileName              = "config.yml"
+	defaultGlobalParamsFileName        = "global_params.json"
+	defaultFinalityProvidersFileName   = "finality_providers.json"
+	defaultDelegationAllowlistFileName = "delegation_allowlist.json"
 )
 
 var (
 	cfgPath                   string
 	globalParamsPath          string
 	finalityProvidersPath     string
+	delegationAllowlistPath   string
 	replayFlag                bool
 	backfillPubkeyAddressFlag bool
 	rootCmd                   = &cobra.Command{
@@ -34,6 +36,7 @@ func Setup() error {
 	defaultConfigPath := getDefaultConfigFile(homePath, defaultConfigFileName)
 	defaultGlobalParamsPath := getDefaultConfigFile(homePath, defaultGlobalParamsFileName)
 	defaultFinalityProvidersPath := getDefaultConfigFile(homePath, defaultFinalityProvidersFileName)
+	defaultDelegationAllowlistPath := getDefaultConfigFile(homePath, defaultDelegationAllowlistFileName)
 
 	rootCmd.PersistentFlags().StringVar(
 		&cfgPath,
@@ -52,6 +55,12 @@ func Setup() error {
 		"finality-providers",
 		defaultFinalityProvidersPath,
 		fmt.Sprintf("finality providers file (default %s)", defaultFinalityProvidersPath),
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&delegationAllowlistPath,
+		"delegation-allowlist",
+		defaultDelegationAllowlistPath,
+		fmt.Sprintf("delegation allowlist file (default %s)", defaultDelegationAllowlistPath),
 	)
 	rootCmd.PersistentFlags().BoolVar(
 		&replayFlag,
@@ -86,6 +95,10 @@ func GetGlobalParamsPath() string {
 
 func GetFinalityProvidersPath() string {
 	return finalityProvidersPath
+}
+
+func GetDelegationAllowlistPath() string {
+	return delegationAllowlistPath
 }
 
 func GetReplayFlag() bool {

--- a/contrib/images/staking-api-service/entrypoint.sh
+++ b/contrib/images/staking-api-service/entrypoint.sh
@@ -6,6 +6,7 @@ BINARY=${BINARY:-/bin/staking-api-service}
 CONFIG=${CONFIG:-/home/staking-api-service/config.yml}
 PARAMS=${PARAMS:-/home/staking-api-service/global-params.json}
 FINALITY_PROVIDERS=${FINALITY_PROVIDERS:-/home/staking-api-service/finality-providers.json}
+DELEGATION_ALLOWLIST=${DELEGATION_ALLOWLIST:-/home/staking-api-service/delegation-allowlist.json}
 
 if ! [ -f "${BINARY}" ]; then
 	echo "The binary $(basename "${BINARY}") cannot be found."
@@ -27,4 +28,9 @@ if ! [ -f "${FINALITY_PROVIDERS}" ]; then
 	exit 1
 fi
 
-$BINARY --config "$CONFIG" --params "$PARAMS" --finality-providers "$FINALITY_PROVIDERS" 2>&1
+if ! [ -f "${DELEGATION_ALLOWLIST}" ]; then
+	echo "The delegation allowlist file $(basename "${DELEGATION_ALLOWLIST}") cannot be found. Please add the delegation allowlist file to the shared folder. Use the DELEGATION_ALLOWLIST environment variable if the name of the delegation allowlist file is not 'delegation-allowlist.json'"
+	exit 1
+fi
+
+$BINARY --config "$CONFIG" --params "$PARAMS" --finality-providers "$FINALITY_PROVIDERS" --delegation-allowlist "$DELEGATION_ALLOWLIST" 2>&1


### PR DESCRIPTION
This pr adds --delegation-allowlist flag in the api binary so the allow list can be mounted and read by service. 

Note:
No tests/scripts exist yet to consume this file, will add later once @filippos47 has injected the data.