### PR TITLE
fix: new configs shall align the formt using -

### DIFF
--- a/config/config-docker.yml
+++ b/config/config-docker.yml
@@ -10,8 +10,8 @@ server:
   max-content-length: 4096
   health-check-interval: 300 # 5 minutes interval
 delegation-transition:
-  eligible_before_btc_height: 10
-  allow_list_expiration_height: 10
+  eligible-before-btc-height: 10
+  allow-list-expiration-height: 10
 staking-db:
   username: root
   password: example

--- a/internal/shared/config/delegation_transition.go
+++ b/internal/shared/config/delegation_transition.go
@@ -9,17 +9,17 @@ import "errors"
 // 2. The current BBN height is greater than AllowListExpirationHeight
 // (allowing all delegations to transition)
 type DelegationTransitionConfig struct {
-	EligibleBeforeBtcHeight   uint64 `mapstructure:"eligible_before_btc_height"`
-	AllowListExpirationHeight uint64 `mapstructure:"allow_list_expiration_height"`
+	EligibleBeforeBtcHeight   uint64 `mapstructure:"eligible-before-btc-height"`
+	AllowListExpirationHeight uint64 `mapstructure:"allow-list-expiration-height"`
 }
 
 func (cfg *DelegationTransitionConfig) Validate() error {
 	if cfg.EligibleBeforeBtcHeight == 0 {
-		return errors.New("before_btc_height cannot be 0")
+		return errors.New("before-btc-height cannot be 0")
 	}
 
 	if cfg.AllowListExpirationHeight == 0 {
-		return errors.New("allow_list_expiration_height cannot be 0")
+		return errors.New("allow-list-expiration-height cannot be 0")
 	}
 
 	return nil

--- a/internal/v1/service/delegation.go
+++ b/internal/v1/service/delegation.go
@@ -195,7 +195,7 @@ func (s *V1Service) FromDelegationDocument(
 	d *v1model.DelegationDocument, bbnHeight uint64,
 	transitionedFps []*indexerdbmodel.IndexerFinalityProviderDetails,
 ) *DelegationPublic {
-	isTransitioned, isSlashed := s.checkFpStatus(d.FinalityProviderPkHex, transitionedFps)
+	isFpTransitioned, isSlashed := s.checkFpStatus(d.FinalityProviderPkHex, transitionedFps)
 	delPublic := &DelegationPublic{
 		StakingTxHashHex:      d.StakingTxHashHex,
 		StakerPkHex:           d.StakerPkHex,
@@ -210,7 +210,7 @@ func (s *V1Service) FromDelegationDocument(
 			TimeLock:       d.StakingTx.TimeLock,
 		},
 		IsOverflow:              d.IsOverflow,
-		IsEligibleForTransition: isTransitioned && !isSlashed && s.isEligibleForTransition(d, bbnHeight),
+		IsEligibleForTransition: isFpTransitioned && !isSlashed && s.isEligibleForTransition(d, bbnHeight),
 		IsSlashed:               isSlashed,
 	}
 


### PR DESCRIPTION
We shall keep config field name consistent with `-` instead of `_`