### PR TITLE
fix: broken staking and unbonding timelock value

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -804,6 +804,12 @@ const docTemplate = `{
         "indexertypes.BbnStakingParams": {
             "type": "object",
             "properties": {
+                "allow_list_expiration_height": {
+                    "type": "integer"
+                },
+                "btc_activation_height": {
+                    "type": "integer"
+                },
                 "covenant_pks": {
                     "type": "array",
                     "items": {
@@ -837,9 +843,6 @@ const docTemplate = `{
                 "min_staking_value_sat": {
                     "type": "integer"
                 },
-                "min_unbonding_time_blocks": {
-                    "type": "integer"
-                },
                 "slashing_pk_script": {
                     "type": "string"
                 },
@@ -847,6 +850,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "unbonding_fee_sat": {
+                    "type": "integer"
+                },
+                "unbonding_time_blocks": {
                     "type": "integer"
                 },
                 "version": {
@@ -1208,8 +1214,8 @@ const docTemplate = `{
                 "staking_amount": {
                     "type": "integer"
                 },
-                "staking_time": {
-                    "type": "string"
+                "staking_timelock": {
+                    "type": "integer"
                 },
                 "staking_tx_hash_hex": {
                     "type": "string"
@@ -1234,8 +1240,8 @@ const docTemplate = `{
                 "slashing_tx_hex": {
                     "type": "string"
                 },
-                "unbonding_time": {
-                    "type": "string"
+                "unbonding_timelock": {
+                    "type": "integer"
                 },
                 "unbonding_tx": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -796,6 +796,12 @@
         "indexertypes.BbnStakingParams": {
             "type": "object",
             "properties": {
+                "allow_list_expiration_height": {
+                    "type": "integer"
+                },
+                "btc_activation_height": {
+                    "type": "integer"
+                },
                 "covenant_pks": {
                     "type": "array",
                     "items": {
@@ -829,9 +835,6 @@
                 "min_staking_value_sat": {
                     "type": "integer"
                 },
-                "min_unbonding_time_blocks": {
-                    "type": "integer"
-                },
                 "slashing_pk_script": {
                     "type": "string"
                 },
@@ -839,6 +842,9 @@
                     "type": "string"
                 },
                 "unbonding_fee_sat": {
+                    "type": "integer"
+                },
+                "unbonding_time_blocks": {
                     "type": "integer"
                 },
                 "version": {
@@ -1200,8 +1206,8 @@
                 "staking_amount": {
                     "type": "integer"
                 },
-                "staking_time": {
-                    "type": "string"
+                "staking_timelock": {
+                    "type": "integer"
                 },
                 "staking_tx_hash_hex": {
                     "type": "string"
@@ -1226,8 +1232,8 @@
                 "slashing_tx_hex": {
                     "type": "string"
                 },
-                "unbonding_time": {
-                    "type": "string"
+                "unbonding_timelock": {
+                    "type": "integer"
                 },
                 "unbonding_tx": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -107,6 +107,10 @@ definitions:
     type: object
   indexertypes.BbnStakingParams:
     properties:
+      allow_list_expiration_height:
+        type: integer
+      btc_activation_height:
+        type: integer
       covenant_pks:
         items:
           type: string
@@ -129,13 +133,13 @@ definitions:
         type: integer
       min_staking_value_sat:
         type: integer
-      min_unbonding_time_blocks:
-        type: integer
       slashing_pk_script:
         type: string
       slashing_rate:
         type: string
       unbonding_fee_sat:
+        type: integer
+      unbonding_time_blocks:
         type: integer
       version:
         type: integer
@@ -376,8 +380,8 @@ definitions:
         type: string
       staking_amount:
         type: integer
-      staking_time:
-        type: string
+      staking_timelock:
+        type: integer
       staking_tx_hash_hex:
         type: string
       staking_tx_hex:
@@ -393,8 +397,8 @@ definitions:
         type: array
       slashing_tx_hex:
         type: string
-      unbonding_time:
-        type: string
+      unbonding_timelock:
+        type: integer
       unbonding_tx:
         type: string
     type: object

--- a/internal/indexer/db/model/delegation.go
+++ b/internal/indexer/db/model/delegation.go
@@ -27,11 +27,11 @@ type IndexerDelegationDetails struct {
 	ParamsVersion                uint32                          `bson:"params_version"`
 	FinalityProviderBtcPksHex    []string                        `bson:"finality_provider_btc_pks_hex"`
 	StakerBtcPkHex               string                          `bson:"staker_btc_pk_hex"`
-	StakingTime                  uint32                          `bson:"staking_time"`
+	StakingTimeLock              uint32                          `bson:"staking_time"`
 	StakingAmount                uint64                          `bson:"staking_amount"`
 	StakingOutputPkScript        string                          `bson:"staking_output_pk_script"`
 	StakingOutputIdx             uint32                          `bson:"staking_output_idx"`
-	UnbondingTime                uint32                          `bson:"unbonding_time"`
+	UnbondingTimeLock            uint32                          `bson:"unbonding_time"`
 	UnbondingTx                  string                          `bson:"unbonding_tx"`
 	State                        indexertypes.DelegationState    `bson:"state"`
 	SubState                     indexertypes.DelegationSubState `bson:"sub_state,omitempty"`

--- a/internal/v2/service/delegation.go
+++ b/internal/v2/service/delegation.go
@@ -15,7 +15,7 @@ import (
 type DelegationStaking struct {
 	StakingTxHashHex   string `json:"staking_tx_hash_hex"`
 	StakingTxHex       string `json:"staking_tx_hex"`
-	StakingTime        string `json:"staking_time"`
+	StakingTimelock    uint32 `json:"staking_timelock"`
 	StakingAmount      uint64 `json:"staking_amount"`
 	StartHeight        uint32 `json:"start_height,omitempty"`
 	EndHeight          uint32 `json:"end_height,omitempty"`
@@ -30,7 +30,7 @@ type CovenantSignature struct {
 }
 
 type DelegationUnbonding struct {
-	UnbondingTime               string              `json:"unbonding_time"`
+	UnbondingTimelock           uint32              `json:"unbonding_timelock"`
 	UnbondingTx                 string              `json:"unbonding_tx"`
 	CovenantUnbondingSignatures []CovenantSignature `json:"covenant_unbonding_signatures"`
 	SlashingTxHex               string              `json:"slashing_tx_hex"`
@@ -62,7 +62,7 @@ func FromDelegationDocument(delegation indexerdbmodel.IndexerDelegationDetails) 
 		DelegationStaking: DelegationStaking{
 			StakingTxHashHex:   delegation.StakingTxHashHex,
 			StakingTxHex:       delegation.StakingTxHex,
-			StakingTime:        utils.ParseTimestampToIsoFormat(int64(delegation.StakingTime)),
+			StakingTimelock:    delegation.StakingTimeLock,
 			StakingAmount:      delegation.StakingAmount,
 			StartHeight:        delegation.StartHeight,
 			EndHeight:          delegation.EndHeight,
@@ -73,8 +73,8 @@ func FromDelegationDocument(delegation indexerdbmodel.IndexerDelegationDetails) 
 			SlashingTxHex: delegation.SlashingTxHex,
 		},
 		DelegationUnbonding: DelegationUnbonding{
-			UnbondingTime: utils.ParseTimestampToIsoFormat(int64(delegation.UnbondingTime)),
-			UnbondingTx:   delegation.UnbondingTx,
+			UnbondingTimelock: delegation.UnbondingTimeLock,
+			UnbondingTx:       delegation.UnbondingTx,
 			CovenantUnbondingSignatures: getUnbondingSignatures(
 				delegation.CovenantUnbondingSignatures,
 			),


### PR DESCRIPTION
I made a mistake in the previous PR https://github.com/babylonlabs-io/staking-api-service/pull/170/files
the staking&unbonding time in the previous PR was actually timelock value. this breaks the unbonding path