### PR TITLE
chore: deprecate some v1 endpoints

### DIFF
--- a/cmd/staking-api-service/main.go
+++ b/cmd/staking-api-service/main.go
@@ -33,6 +33,19 @@ func init() {
 // @license.name    API Access License
 // @license.url     https://docs.babylonlabs.io/assets/files/api-access-license.pdf
 // @contact.email   contact@babylonlabs.io
+
+// @tag.name shared
+// @tag.description Shared API endpoints
+// @tag.order 1
+
+// @tag.name v2
+// @tag.description Babylon Phase-2 API endpoints
+// @tag.order 2
+
+// @tag.name v1
+// @tag.description Babylon Phase-1 API endpoints (Deprecated)
+// @tag.deprecated
+// @tag.order 2
 func main() {
 	ctx := context.Background()
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,13 +43,14 @@ const docTemplate = `{
         },
         "/v1/delegation": {
             "get": {
-                "description": "Retrieves a delegation by a given transaction hash",
+                "description": "[DEPRECATED] Retrieves a delegation by a given transaction hash. Please use /v2/delegation instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -77,14 +78,15 @@ const docTemplate = `{
         },
         "/v1/finality-providers": {
             "get": {
-                "description": "Fetches details of all active finality providers sorted by their active total value locked (ActiveTvl) in descending order.",
+                "description": "[DEPRECATED] Fetches details of all active finality providers sorted by their active total value locked (ActiveTvl) in descending order. Please use /v2/finality-providers instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Active Finality Providers",
+                "summary": "Get Active Finality Providers (Deprecated)",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -111,14 +113,14 @@ const docTemplate = `{
         },
         "/v1/global-params": {
             "get": {
-                "description": "Retrieves the global parameters for Babylon, including finality provider details.",
+                "description": "[DEPRECATED] Retrieves the global parameters for Babylon, including finality provider details. Please use /v2/network-info instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Babylon global parameters",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "Global parameters",
@@ -131,12 +133,12 @@ const docTemplate = `{
         },
         "/v1/staker/delegation/check": {
             "get": {
-                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
+                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit).\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "v1"
+                    "shared"
                 ],
                 "parameters": [
                     {
@@ -174,7 +176,7 @@ const docTemplate = `{
         },
         "/v1/staker/delegations": {
             "get": {
-                "description": "Retrieves delegations for a given staker",
+                "description": "Retrieves phase-1 delegations for a given staker. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.\nThis endpoint is only used to show legacy phase-1 delegations for the purpose of unbonding or registering into phase-2.",
                 "produces": [
                     "application/json"
                 ],
@@ -220,13 +222,14 @@ const docTemplate = `{
         },
         "/v1/staker/pubkey-lookup": {
             "get": {
-                "description": "Retrieves public keys for the given BTC addresses. This endpoint",
+                "description": "Retrieves public keys for the given BTC addresses. This endpoint\nonly returns public keys for addresses that have associated delegations in\nthe system. If an address has no associated delegation, it will not be\nincluded in the response. Supports both Taproot and Native Segwit addresses.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "v1"
+                    "shared"
                 ],
+                "summary": "Get stakers' public keys",
                 "parameters": [
                     {
                         "type": "array",
@@ -244,7 +247,7 @@ const docTemplate = `{
                     "200": {
                         "description": "A map of BTC addresses to their corresponding public keys (only addresses with delegations are returned)",
                         "schema": {
-                            "$ref": "#/definitions/handler.Result"
+                            "$ref": "#/definitions/handler.PublicResponse-map_string_string"
                         }
                     },
                     "400": {
@@ -264,14 +267,15 @@ const docTemplate = `{
         },
         "/v1/stats": {
             "get": {
-                "description": "Fetches overall stats for babylon staking including tvl, total delegations, active tvl, active delegations and total stakers.",
+                "description": "[DEPRECATED] Fetches overall stats for babylon staking including tvl, total delegations, active tvl, active delegations and total stakers. Please use /v2/stats instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Overall Stats",
+                "summary": "Get Overall Stats (Deprecated)",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "Overall stats for babylon staking",
@@ -284,14 +288,15 @@ const docTemplate = `{
         },
         "/v1/stats/staker": {
             "get": {
-                "description": "Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations.\nIf staker_btc_pk query parameter is provided, it will return stats for the specific staker.\nOtherwise, it will return the top stakers ranked by active tvl.",
+                "description": "[DEPRECATED] Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations. Please use /v2/staker/stats instead.\nIf staker_btc_pk query parameter is provided, it will return stats for the specific staker.\nOtherwise, it will return the top stakers ranked by active tvl.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Staker Stats",
+                "summary": "Get Staker Stats (Deprecated)",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -324,7 +329,7 @@ const docTemplate = `{
         },
         "/v1/unbonding": {
             "post": {
-                "description": "Unbonds a delegation by processing the provided transaction details. This is an async operation.",
+                "description": "Unbonds a phase-1 delegation by processing the provided transaction details. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.\nThis is an async operation.",
                 "consumes": [
                     "application/json"
                 ],
@@ -334,7 +339,7 @@ const docTemplate = `{
                 "tags": [
                     "v1"
                 ],
-                "summary": "Unbond delegation",
+                "summary": "Unbond phase-1 delegation",
                 "parameters": [
                     {
                         "description": "Unbonding Request Payload",
@@ -361,7 +366,7 @@ const docTemplate = `{
         },
         "/v1/unbonding/eligibility": {
             "get": {
-                "description": "Checks if a delegation identified by its staking transaction hash is eligible for unbonding.",
+                "description": "Checks if a delegation identified by its staking transaction hash is eligible for unbonding. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.",
                 "produces": [
                     "application/json"
                 ],
@@ -710,6 +715,17 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.PublicResponse-map_string_string": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/map_string_string"
+                },
+                "pagination": {
+                    "$ref": "#/definitions/handler.paginationResponse"
+                }
+            }
+        },
         "handler.PublicResponse-v1service_DelegationPublic": {
             "type": "object",
             "properties": {
@@ -773,15 +789,6 @@ const docTemplate = `{
                 },
                 "pagination": {
                     "$ref": "#/definitions/handler.paginationResponse"
-                }
-            }
-        },
-        "handler.Result": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "status": {
-                    "type": "integer"
                 }
             }
         },
@@ -861,6 +868,12 @@ const docTemplate = `{
                 "version": {
                     "type": "integer"
                 }
+            }
+        },
+        "map_string_string": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
             }
         },
         "types.ErrorCode": {
@@ -1402,7 +1415,21 @@ const docTemplate = `{
                 "StateEarlyUnbondingSlashingWithdrawn"
             ]
         }
-    }
+    },
+    "tags": [
+        {
+            "description": "Shared API endpoints",
+            "name": "shared"
+        },
+        {
+            "description": "Babylon Phase-2 API endpoints",
+            "name": "v2"
+        },
+        {
+            "description": "Babylon Phase-1 API endpoints (Deprecated)",
+            "name": "v1"
+        }
+    ]
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -35,13 +35,14 @@
         },
         "/v1/delegation": {
             "get": {
-                "description": "Retrieves a delegation by a given transaction hash",
+                "description": "[DEPRECATED] Retrieves a delegation by a given transaction hash. Please use /v2/delegation instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -69,14 +70,15 @@
         },
         "/v1/finality-providers": {
             "get": {
-                "description": "Fetches details of all active finality providers sorted by their active total value locked (ActiveTvl) in descending order.",
+                "description": "[DEPRECATED] Fetches details of all active finality providers sorted by their active total value locked (ActiveTvl) in descending order. Please use /v2/finality-providers instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Active Finality Providers",
+                "summary": "Get Active Finality Providers (Deprecated)",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -103,14 +105,14 @@
         },
         "/v1/global-params": {
             "get": {
-                "description": "Retrieves the global parameters for Babylon, including finality provider details.",
+                "description": "[DEPRECATED] Retrieves the global parameters for Babylon, including finality provider details. Please use /v2/network-info instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Babylon global parameters",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "Global parameters",
@@ -123,12 +125,12 @@
         },
         "/v1/staker/delegation/check": {
             "get": {
-                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
+                "description": "Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit).\nOptionally, you can provide a timeframe to check if the delegation is active within the provided timeframe\nThe available timeframe is \"today\" which checks after UTC 12AM of the current day",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "v1"
+                    "shared"
                 ],
                 "parameters": [
                     {
@@ -166,7 +168,7 @@
         },
         "/v1/staker/delegations": {
             "get": {
-                "description": "Retrieves delegations for a given staker",
+                "description": "Retrieves phase-1 delegations for a given staker. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.\nThis endpoint is only used to show legacy phase-1 delegations for the purpose of unbonding or registering into phase-2.",
                 "produces": [
                     "application/json"
                 ],
@@ -212,13 +214,14 @@
         },
         "/v1/staker/pubkey-lookup": {
             "get": {
-                "description": "Retrieves public keys for the given BTC addresses. This endpoint",
+                "description": "Retrieves public keys for the given BTC addresses. This endpoint\nonly returns public keys for addresses that have associated delegations in\nthe system. If an address has no associated delegation, it will not be\nincluded in the response. Supports both Taproot and Native Segwit addresses.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "v1"
+                    "shared"
                 ],
+                "summary": "Get stakers' public keys",
                 "parameters": [
                     {
                         "type": "array",
@@ -236,7 +239,7 @@
                     "200": {
                         "description": "A map of BTC addresses to their corresponding public keys (only addresses with delegations are returned)",
                         "schema": {
-                            "$ref": "#/definitions/handler.Result"
+                            "$ref": "#/definitions/handler.PublicResponse-map_string_string"
                         }
                     },
                     "400": {
@@ -256,14 +259,15 @@
         },
         "/v1/stats": {
             "get": {
-                "description": "Fetches overall stats for babylon staking including tvl, total delegations, active tvl, active delegations and total stakers.",
+                "description": "[DEPRECATED] Fetches overall stats for babylon staking including tvl, total delegations, active tvl, active delegations and total stakers. Please use /v2/stats instead.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Overall Stats",
+                "summary": "Get Overall Stats (Deprecated)",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "Overall stats for babylon staking",
@@ -276,14 +280,15 @@
         },
         "/v1/stats/staker": {
             "get": {
-                "description": "Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations.\nIf staker_btc_pk query parameter is provided, it will return stats for the specific staker.\nOtherwise, it will return the top stakers ranked by active tvl.",
+                "description": "[DEPRECATED] Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations. Please use /v2/staker/stats instead.\nIf staker_btc_pk query parameter is provided, it will return stats for the specific staker.\nOtherwise, it will return the top stakers ranked by active tvl.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "v1"
                 ],
-                "summary": "Get Staker Stats",
+                "summary": "Get Staker Stats (Deprecated)",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -316,7 +321,7 @@
         },
         "/v1/unbonding": {
             "post": {
-                "description": "Unbonds a delegation by processing the provided transaction details. This is an async operation.",
+                "description": "Unbonds a phase-1 delegation by processing the provided transaction details. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.\nThis is an async operation.",
                 "consumes": [
                     "application/json"
                 ],
@@ -326,7 +331,7 @@
                 "tags": [
                     "v1"
                 ],
-                "summary": "Unbond delegation",
+                "summary": "Unbond phase-1 delegation",
                 "parameters": [
                     {
                         "description": "Unbonding Request Payload",
@@ -353,7 +358,7 @@
         },
         "/v1/unbonding/eligibility": {
             "get": {
-                "description": "Checks if a delegation identified by its staking transaction hash is eligible for unbonding.",
+                "description": "Checks if a delegation identified by its staking transaction hash is eligible for unbonding. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.",
                 "produces": [
                     "application/json"
                 ],
@@ -702,6 +707,17 @@
                 }
             }
         },
+        "handler.PublicResponse-map_string_string": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/map_string_string"
+                },
+                "pagination": {
+                    "$ref": "#/definitions/handler.paginationResponse"
+                }
+            }
+        },
         "handler.PublicResponse-v1service_DelegationPublic": {
             "type": "object",
             "properties": {
@@ -765,15 +781,6 @@
                 },
                 "pagination": {
                     "$ref": "#/definitions/handler.paginationResponse"
-                }
-            }
-        },
-        "handler.Result": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "status": {
-                    "type": "integer"
                 }
             }
         },
@@ -853,6 +860,12 @@
                 "version": {
                     "type": "integer"
                 }
+            }
+        },
+        "map_string_string": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
             }
         },
         "types.ErrorCode": {
@@ -1394,5 +1407,19 @@
                 "StateEarlyUnbondingSlashingWithdrawn"
             ]
         }
-    }
+    },
+    "tags": [
+        {
+            "description": "Shared API endpoints",
+            "name": "shared"
+        },
+        {
+            "description": "Babylon Phase-2 API endpoints",
+            "name": "v2"
+        },
+        {
+            "description": "Babylon Phase-1 API endpoints (Deprecated)",
+            "name": "v1"
+        }
+    ]
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -52,6 +52,13 @@ definitions:
       pagination:
         $ref: '#/definitions/handler.paginationResponse'
     type: object
+  handler.PublicResponse-map_string_string:
+    properties:
+      data:
+        $ref: '#/definitions/map_string_string'
+      pagination:
+        $ref: '#/definitions/handler.paginationResponse'
+    type: object
   handler.PublicResponse-v1service_DelegationPublic:
     properties:
       data:
@@ -93,12 +100,6 @@ definitions:
         $ref: '#/definitions/v2service.StakerStatsPublic'
       pagination:
         $ref: '#/definitions/handler.paginationResponse'
-    type: object
-  handler.Result:
-    properties:
-      data: {}
-      status:
-        type: integer
     type: object
   handler.paginationResponse:
     properties:
@@ -150,6 +151,10 @@ definitions:
         type: integer
       version:
         type: integer
+    type: object
+  map_string_string:
+    additionalProperties:
+      type: string
     type: object
   types.ErrorCode:
     enum:
@@ -543,7 +548,9 @@ paths:
       - shared
   /v1/delegation:
     get:
-      description: Retrieves a delegation by a given transaction hash
+      deprecated: true
+      description: '[DEPRECATED] Retrieves a delegation by a given transaction hash.
+        Please use /v2/delegation instead.'
       parameters:
       - description: Staking transaction hash in hex format
         in: query
@@ -565,8 +572,10 @@ paths:
       - v1
   /v1/finality-providers:
     get:
-      description: Fetches details of all active finality providers sorted by their
-        active total value locked (ActiveTvl) in descending order.
+      deprecated: true
+      description: '[DEPRECATED] Fetches details of all active finality providers
+        sorted by their active total value locked (ActiveTvl) in descending order.
+        Please use /v2/finality-providers instead.'
       parameters:
       - description: Public key of the finality provider to fetch
         in: query
@@ -584,13 +593,14 @@ paths:
             order
           schema:
             $ref: '#/definitions/handler.PublicResponse-array_v1service_FpDetailsPublic'
-      summary: Get Active Finality Providers
+      summary: Get Active Finality Providers (Deprecated)
       tags:
       - v1
   /v1/global-params:
     get:
-      description: Retrieves the global parameters for Babylon, including finality
-        provider details.
+      deprecated: true
+      description: '[DEPRECATED] Retrieves the global parameters for Babylon, including
+        finality provider details. Please use /v2/network-info instead.'
       produces:
       - application/json
       responses:
@@ -598,13 +608,12 @@ paths:
           description: Global parameters
           schema:
             $ref: '#/definitions/handler.PublicResponse-v1service_GlobalParamsPublic'
-      summary: Get Babylon global parameters
       tags:
       - v1
   /v1/staker/delegation/check:
     get:
       description: |-
-        Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)
+        Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit).
         Optionally, you can provide a timeframe to check if the delegation is active within the provided timeframe
         The available timeframe is "today" which checks after UTC 12AM of the current day
       parameters:
@@ -631,10 +640,12 @@ paths:
           schema:
             $ref: '#/definitions/github_com_babylonlabs-io_staking-api-service_internal_shared_types.Error'
       tags:
-      - v1
+      - shared
   /v1/staker/delegations:
     get:
-      description: Retrieves delegations for a given staker
+      description: |-
+        Retrieves phase-1 delegations for a given staker. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.
+        This endpoint is only used to show legacy phase-1 delegations for the purpose of unbonding or registering into phase-2.
       parameters:
       - description: Staker BTC Public Key
         in: query
@@ -665,7 +676,11 @@ paths:
       - v1
   /v1/staker/pubkey-lookup:
     get:
-      description: Retrieves public keys for the given BTC addresses. This endpoint
+      description: |-
+        Retrieves public keys for the given BTC addresses. This endpoint
+        only returns public keys for addresses that have associated delegations in
+        the system. If an address has no associated delegation, it will not be
+        included in the response. Supports both Taproot and Native Segwit addresses.
       parameters:
       - collectionFormat: multi
         description: List of BTC addresses to look up (up to 10), currently only supports
@@ -683,7 +698,7 @@ paths:
           description: A map of BTC addresses to their corresponding public keys (only
             addresses with delegations are returned)
           schema:
-            $ref: '#/definitions/handler.Result'
+            $ref: '#/definitions/handler.PublicResponse-map_string_string'
         "400":
           description: 'Bad Request: Invalid input parameters'
           schema:
@@ -692,12 +707,15 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/github_com_babylonlabs-io_staking-api-service_internal_shared_types.Error'
+      summary: Get stakers' public keys
       tags:
-      - v1
+      - shared
   /v1/stats:
     get:
-      description: Fetches overall stats for babylon staking including tvl, total
-        delegations, active tvl, active delegations and total stakers.
+      deprecated: true
+      description: '[DEPRECATED] Fetches overall stats for babylon staking including
+        tvl, total delegations, active tvl, active delegations and total stakers.
+        Please use /v2/stats instead.'
       produces:
       - application/json
       responses:
@@ -705,13 +723,14 @@ paths:
           description: Overall stats for babylon staking
           schema:
             $ref: '#/definitions/handler.PublicResponse-v1service_OverallStatsPublic'
-      summary: Get Overall Stats
+      summary: Get Overall Stats (Deprecated)
       tags:
       - v1
   /v1/stats/staker:
     get:
+      deprecated: true
       description: |-
-        Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations.
+        [DEPRECATED] Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations. Please use /v2/staker/stats instead.
         If staker_btc_pk query parameter is provided, it will return stats for the specific staker.
         Otherwise, it will return the top stakers ranked by active tvl.
       parameters:
@@ -734,14 +753,15 @@ paths:
           description: 'Error: Bad Request'
           schema:
             $ref: '#/definitions/github_com_babylonlabs-io_staking-api-service_internal_shared_types.Error'
-      summary: Get Staker Stats
+      summary: Get Staker Stats (Deprecated)
       tags:
       - v1
   /v1/unbonding:
     post:
       consumes:
       - application/json
-      description: Unbonds a delegation by processing the provided transaction details.
+      description: |-
+        Unbonds a phase-1 delegation by processing the provided transaction details. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.
         This is an async operation.
       parameters:
       - description: Unbonding Request Payload
@@ -759,13 +779,14 @@ paths:
           description: Invalid request payload
           schema:
             $ref: '#/definitions/github_com_babylonlabs-io_staking-api-service_internal_shared_types.Error'
-      summary: Unbond delegation
+      summary: Unbond phase-1 delegation
       tags:
       - v1
   /v1/unbonding/eligibility:
     get:
       description: Checks if a delegation identified by its staking transaction hash
-        is eligible for unbonding.
+        is eligible for unbonding. This endpoint will be deprecated once all phase-1
+        delegations are either withdrawn or registered into phase-2.
       parameters:
       - description: Staking Transaction Hash Hex
         in: query
@@ -942,3 +963,10 @@ paths:
       tags:
       - v2
 swagger: "2.0"
+tags:
+- description: Shared API endpoints
+  name: shared
+- description: Babylon Phase-2 API endpoints
+  name: v2
+- description: Babylon Phase-1 API endpoints (Deprecated)
+  name: v1

--- a/internal/v1/api/handlers/delegation.go
+++ b/internal/v1/api/handlers/delegation.go
@@ -7,10 +7,11 @@ import (
 	"github.com/babylonlabs-io/staking-api-service/internal/shared/types"
 )
 
-// GetDelegationByTxHash @Summary Get a delegation
-// @Description Retrieves a delegation by a given transaction hash
+// GetDelegationByTxHash @Summary Get a delegation (Deprecated)
+// @Description [DEPRECATED] Retrieves a delegation by a given transaction hash. Please use /v2/delegation instead.
 // @Produce json
 // @Tags v1
+// @Deprecated
 // @Param staking_tx_hash_hex query string true "Staking transaction hash in hex format"
 // @Success 200 {object} handler.PublicResponse[v1service.DelegationPublic] "Delegation"
 // @Failure 400 {object} types.Error "Error: Bad Request"

--- a/internal/v1/api/handlers/finality_provider.go
+++ b/internal/v1/api/handlers/finality_provider.go
@@ -9,10 +9,11 @@ import (
 )
 
 // GetFinalityProviders gets active finality providers sorted by ActiveTvl.
-// @Summary Get Active Finality Providers
-// @Description Fetches details of all active finality providers sorted by their active total value locked (ActiveTvl) in descending order.
+// @Summary Get Active Finality Providers (Deprecated)
+// @Description [DEPRECATED] Fetches details of all active finality providers sorted by their active total value locked (ActiveTvl) in descending order. Please use /v2/finality-providers instead.
 // @Produce json
 // @Tags v1
+// @Deprecated
 // @Param fp_btc_pk query string false "Public key of the finality provider to fetch"
 // @Param pagination_key query string false "Pagination key to fetch the next page of finality providers"
 // @Success 200 {object} handler.PublicResponse[[]v1service.FpDetailsPublic] "A list of finality providers sorted by ActiveTvl in descending order"

--- a/internal/v1/api/handlers/params.go
+++ b/internal/v1/api/handlers/params.go
@@ -7,11 +7,11 @@ import (
 	"github.com/babylonlabs-io/staking-api-service/internal/shared/types"
 )
 
-// GetBabylonGlobalParams godoc
-// @Summary Get Babylon global parameters
-// @Description Retrieves the global parameters for Babylon, including finality provider details.
+// GetBabylonGlobalParams @Summary Get Babylon global parameters (Deprecated)
+// @Description [DEPRECATED] Retrieves the global parameters for Babylon, including finality provider details. Please use /v2/network-info instead.
 // @Produce json
 // @Tags v1
+// @Deprecated
 // @Success 200 {object} handler.PublicResponse[v1service.GlobalParamsPublic] "Global parameters"
 // @Router /v1/global-params [get]
 func (h *V1Handler) GetBabylonGlobalParams(request *http.Request) (*handler.Result, *types.Error) {

--- a/internal/v1/api/handlers/pubkey.go
+++ b/internal/v1/api/handlers/pubkey.go
@@ -18,15 +18,16 @@ const (
 	MAX_NUM_PK_LOOKUP_ADDRESSES = 10
 )
 
-// GetPubKeys @Summary Get stakers' public keys
+// GetPubKeys godoc
+// @Summary Get stakers' public keys
 // @Description Retrieves public keys for the given BTC addresses. This endpoint
-// only returns public keys for addresses that have associated delegations in
-// the system. If an address has no associated delegation, it will not be
-// included in the response. Supports both Taproot and Native Segwit addresses.
+// @Description only returns public keys for addresses that have associated delegations in
+// @Description the system. If an address has no associated delegation, it will not be
+// @Description included in the response. Supports both Taproot and Native Segwit addresses.
 // @Produce json
-// @Tags v1
+// @Tags shared
 // @Param address query []string true "List of BTC addresses to look up (up to 10), currently only supports Taproot and Native Segwit addresses" collectionFormat(multi)
-// @Success 200 {object} handler.Result[map[string]string] "A map of BTC addresses to their corresponding public keys (only addresses with delegations are returned)"
+// @Success 200 {object} handler.PublicResponse[map[string]string] "A map of BTC addresses to their corresponding public keys (only addresses with delegations are returned)"
 // @Failure 400 {object} types.Error "Bad Request: Invalid input parameters"
 // @Failure 500 {object} types.Error "Internal Server Error"
 // @Router /v1/staker/pubkey-lookup [get]

--- a/internal/v1/api/handlers/staker.go
+++ b/internal/v1/api/handlers/staker.go
@@ -13,8 +13,9 @@ type DelegationCheckPublicResponse struct {
 	Code int  `json:"code"`
 }
 
-// GetStakerDelegations @Summary Get staker delegations
-// @Description Retrieves delegations for a given staker
+// GetStakerDelegations @Summary Get phase-1 staker delegations
+// @Description Retrieves phase-1 delegations for a given staker. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.
+// @Description This endpoint is only used to show legacy phase-1 delegations for the purpose of unbonding or registering into phase-2.
 // @Produce json
 // @Tags v1
 // @Param staker_btc_pk query string true "Staker BTC Public Key"
@@ -57,11 +58,11 @@ func (h *V1Handler) GetStakerDelegations(request *http.Request) (*handler.Result
 }
 
 // CheckStakerDelegationExist @Summary Check if a staker has an active delegation
-// @Description Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit)
+// @Description Check if a staker has an active delegation by the staker BTC address (Taproot or Native Segwit).
 // @Description Optionally, you can provide a timeframe to check if the delegation is active within the provided timeframe
 // @Description The available timeframe is "today" which checks after UTC 12AM of the current day
 // @Produce json
-// @Tags v1
+// @Tags shared
 // @Param address query string true "Staker BTC address in Taproot/Native Segwit format"
 // @Param timeframe query string false "Check if the delegation is active within the provided timeframe" Enums(today)
 // @Success 200 {object} DelegationCheckPublicResponse "Delegation check result"

--- a/internal/v1/api/handlers/stats.go
+++ b/internal/v1/api/handlers/stats.go
@@ -9,10 +9,11 @@ import (
 )
 
 // GetOverallStats gets overall stats for babylon staking
-// @Summary Get Overall Stats
-// @Description Fetches overall stats for babylon staking including tvl, total delegations, active tvl, active delegations and total stakers.
+// @Summary Get Overall Stats (Deprecated)
+// @Description [DEPRECATED] Fetches overall stats for babylon staking including tvl, total delegations, active tvl, active delegations and total stakers. Please use /v2/stats instead.
 // @Produce json
 // @Tags v1
+// @Deprecated
 // @Success 200 {object} handler.PublicResponse[v1service.OverallStatsPublic] "Overall stats for babylon staking"
 // @Router /v1/stats [get]
 func (h *V1Handler) GetOverallStats(request *http.Request) (*handler.Result, *types.Error) {
@@ -25,12 +26,13 @@ func (h *V1Handler) GetOverallStats(request *http.Request) (*handler.Result, *ty
 }
 
 // GetStakersStats gets staker stats for babylon staking
-// @Summary Get Staker Stats
-// @Description Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations.
+// @Summary Get Staker Stats (Deprecated)
+// @Description [DEPRECATED] Fetches staker stats for babylon staking including tvl, total delegations, active tvl and active delegations. Please use /v2/staker/stats instead.
 // @Description If staker_btc_pk query parameter is provided, it will return stats for the specific staker.
 // @Description Otherwise, it will return the top stakers ranked by active tvl.
 // @Produce json
 // @Tags v1
+// @Deprecated
 // @Param  staker_btc_pk query string false "Public key of the staker to fetch"
 // @Param  pagination_key query string false "Pagination key to fetch the next page of top stakers"
 // @Success 200 {object} handler.PublicResponse[[]v1service.StakerStatsPublic]{array} "List of top stakers by active tvl"

--- a/internal/v1/api/handlers/unbonding.go
+++ b/internal/v1/api/handlers/unbonding.go
@@ -48,8 +48,9 @@ func parseUnbondDelegationRequestPayload(request *http.Request) (*UnbondDelegati
 }
 
 // UnbondDelegation godoc
-// @Summary Unbond delegation
-// @Description Unbonds a delegation by processing the provided transaction details. This is an async operation.
+// @Summary Unbond phase-1 delegation
+// @Description Unbonds a phase-1 delegation by processing the provided transaction details. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.
+// @Description This is an async operation.
 // @Accept json
 // @Produce json
 // @Tags v1
@@ -76,7 +77,7 @@ func (h *V1Handler) UnbondDelegation(request *http.Request) (*handler.Result, *t
 
 // GetUnbondingEligibility godoc
 // @Summary Check unbonding eligibility
-// @Description Checks if a delegation identified by its staking transaction hash is eligible for unbonding.
+// @Description Checks if a delegation identified by its staking transaction hash is eligible for unbonding. This endpoint will be deprecated once all phase-1 delegations are either withdrawn or registered into phase-2.
 // @Produce json
 // @Tags v1
 // @Param staking_tx_hash_hex query string true "Staking Transaction Hash Hex"


### PR DESCRIPTION
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/8103517b-435b-435f-b398-319d26d13456" />

Deprecating some of the v1 endpoints as we won't be using it for phase-2. It's quite confusing for partners