### PR TITLE
Add manual test for coinmarketcap

### DIFF
--- a/internal/shared/http/clients/http_clients_test.go
+++ b/internal/shared/http/clients/http_clients_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCMC(t *testing.T) {
-	t.Skip("test for manual testing")
+	t.Skip("manual test")
 
 	const envVarName = "COINMARKETCAP_API_KEY"
 	apiKey, found := os.LookupEnv(envVarName)

--- a/internal/shared/http/clients/http_clients_test.go
+++ b/internal/shared/http/clients/http_clients_test.go
@@ -1,0 +1,33 @@
+package clients
+
+import (
+	"testing"
+	"github.com/babylonlabs-io/staking-api-service/internal/shared/config"
+	coinmarketcap "github.com/miguelmota/go-coinmarketcap/pro/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/davecgh/go-spew/spew"
+	"os"
+)
+
+func TestCMC(t *testing.T) {
+	t.Skip("test for manual testing")
+
+	const envVarName = "COINMARKETCAP_API_KEY"
+	apiKey, found := os.LookupEnv(envVarName)
+	require.True(t, found, "%s env var is required", envVarName)
+
+	clients := New(&config.Config{
+		ExternalAPIs: &config.ExternalAPIsConfig{
+			CoinMarketCap: &config.CoinMarketCapConfig{
+				APIKey:  apiKey,
+				BaseURL: "https://pro-api.coinmarketcap.com/v1",
+			},
+		},
+	})
+	quotes, err := clients.CoinMarketCap.Cryptocurrency.LatestQuotes(&coinmarketcap.QuoteOptions{
+		Symbol: "BTC",
+	})
+	require.NoError(t, err)
+
+	spew.Dump(quotes)
+}


### PR DESCRIPTION
This type of tests quite helpful if you want to test external API manually on your local machine.
Note that it's skipped by default to prevent it from running in our test suite