### PR TITLE
Enable staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,7 @@ linters:
     - nilerr
     - gocyclo
     - gocritic
+    - staticcheck
   # todo enable after golangci-lint update to 1.63
 #    - gosec
   #    - prealloc
@@ -96,7 +97,6 @@ linters:
   #    - unused
   #    - govet
   #    - nakedret
-  #    - staticcheck
   # - nilnesserr
   # - usetesting
   # - exhaustruct

--- a/internal/shared/api/handlers/handler/ordinals.go
+++ b/internal/shared/api/handlers/handler/ordinals.go
@@ -31,8 +31,6 @@ func parseRequestPayload(request *http.Request, maxUTXOs uint32, netParam *chain
 	for _, utxo := range utxos {
 		if !utils.IsValidTxHash(utxo.Txid) {
 			return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, "invalid UTXO txid")
-		} else if utxo.Vout < 0 {
-			return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, "invalid UTXO vout")
 		}
 	}
 


### PR DESCRIPTION
1. Enabled `staticheck` linter (helpful to find error like `wrong usage of break statement`)
2. Removed impossible if condition (the linter found it)