### PR TITLE
Skip logo fetching for fp-s with empty identity field

### DIFF
--- a/internal/v2/service/finality_provider.go
+++ b/internal/v2/service/finality_provider.go
@@ -135,6 +135,11 @@ func (s *V2Service) fetchLogos(ctx context.Context, fps []*indexerdbmodel.Indexe
 			continue
 		}
 
+		// identity used as id for logo retrieval
+		if fp.Description.Identity == "" {
+			continue
+		}
+
 		missingLogos <- logoToUpdate{
 			identity: fp.Description.Identity,
 			btcPK:    fp.BtcPk,


### PR DESCRIPTION
Noticed on devnet that we keep fetching logos for fp-s with empty identity field.