### PR TITLE
fix: should default to BABY FPs when bsn_id query is not present

### DIFF
--- a/config/config-local.yml
+++ b/config/config-local.yml
@@ -19,7 +19,7 @@ staking-db:
 indexer-db:
   username: root
   password: example
-  address: "mongodb://localhost:27019/?directConnection=true"
+  address: "mongodb://localhost:27017/?directConnection=true"
   db-name: babylon-staking-indexer
   max-pagination-limit: 10
 queue:

--- a/internal/indexer/db/client/finality_provider.go
+++ b/internal/indexer/db/client/finality_provider.go
@@ -17,8 +17,17 @@ func (indexerdbclient *IndexerDatabase) GetFinalityProviders(
 	).Collection(indexerdbmodel.FinalityProviderDetailsCollection)
 
 	filter := bson.M{}
-	if bsnID != nil {
+	if bsnID != nil && *bsnID != "" {
 		filter["bsn_id"] = *bsnID
+	} else {
+		// When bsnID is nil or empty, fetch items that don't have bsn_id field or have empty string
+		// TODO: temporary solution until figure out the bsn_id for BABY chain
+		filter = bson.M{
+			"$or": []bson.M{
+				{"bsn_id": bson.M{"$exists": false}},
+				{"bsn_id": ""},
+			},
+		}
 	}
 
 	cursor, err := client.Find(ctx, filter)


### PR DESCRIPTION
<img width="719" alt="image" src="https://github.com/user-attachments/assets/c5e088d5-83f2-4ecc-a41d-d74ef6f44abf" />
