### PR TITLE
feat: delegation to include expanded state

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1549,11 +1549,11 @@ const docTemplate = `{
         "v2service.StakingStatusPublic": {
             "type": "object",
             "properties": {
-                "allow_list": {
-                    "$ref": "#/definitions/v2service.AllowListPublic"
-                },
                 "is_staking_open": {
                     "type": "boolean"
+                },
+                "staking_expansion_allow_list": {
+                    "$ref": "#/definitions/v2service.AllowListPublic"
                 }
             }
         },
@@ -1584,7 +1584,8 @@ const docTemplate = `{
                 "TIMELOCK_WITHDRAWN",
                 "EARLY_UNBONDING_WITHDRAWN",
                 "TIMELOCK_SLASHING_WITHDRAWN",
-                "EARLY_UNBONDING_SLASHING_WITHDRAWN"
+                "EARLY_UNBONDING_SLASHING_WITHDRAWN",
+                "EXPANDED"
             ],
             "x-enum-varnames": [
                 "StatePending",
@@ -1600,7 +1601,8 @@ const docTemplate = `{
                 "StateTimelockWithdrawn",
                 "StateEarlyUnbondingWithdrawn",
                 "StateTimelockSlashingWithdrawn",
-                "StateEarlyUnbondingSlashingWithdrawn"
+                "StateEarlyUnbondingSlashingWithdrawn",
+                "StateExpanded"
             ]
         }
     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1541,11 +1541,11 @@
         "v2service.StakingStatusPublic": {
             "type": "object",
             "properties": {
-                "staking_expansion_allow_list": {
-                    "$ref": "#/definitions/v2service.AllowListPublic"
-                },
                 "is_staking_open": {
                     "type": "boolean"
+                },
+                "staking_expansion_allow_list": {
+                    "$ref": "#/definitions/v2service.AllowListPublic"
                 }
             }
         },
@@ -1576,7 +1576,8 @@
                 "TIMELOCK_WITHDRAWN",
                 "EARLY_UNBONDING_WITHDRAWN",
                 "TIMELOCK_SLASHING_WITHDRAWN",
-                "EARLY_UNBONDING_SLASHING_WITHDRAWN"
+                "EARLY_UNBONDING_SLASHING_WITHDRAWN",
+                "EXPANDED"
             ],
             "x-enum-varnames": [
                 "StatePending",
@@ -1592,7 +1593,8 @@
                 "StateTimelockWithdrawn",
                 "StateEarlyUnbondingWithdrawn",
                 "StateTimelockSlashingWithdrawn",
-                "StateEarlyUnbondingSlashingWithdrawn"
+                "StateEarlyUnbondingSlashingWithdrawn",
+                "StateExpanded"
             ]
         }
     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -564,10 +564,10 @@ definitions:
     type: object
   v2service.StakingStatusPublic:
     properties:
-      staking_expansion_allow_list:
-        $ref: '#/definitions/v2service.AllowListPublic'
       is_staking_open:
         type: boolean
+      staking_expansion_allow_list:
+        $ref: '#/definitions/v2service.AllowListPublic'
     type: object
   v2service.UnbondingSlashing:
     properties:
@@ -592,6 +592,7 @@ definitions:
     - EARLY_UNBONDING_WITHDRAWN
     - TIMELOCK_SLASHING_WITHDRAWN
     - EARLY_UNBONDING_SLASHING_WITHDRAWN
+    - EXPANDED
     type: string
     x-enum-varnames:
     - StatePending
@@ -608,6 +609,7 @@ definitions:
     - StateEarlyUnbondingWithdrawn
     - StateTimelockSlashingWithdrawn
     - StateEarlyUnbondingSlashingWithdrawn
+    - StateExpanded
 info:
   contact:
     email: contact@babylonlabs.io

--- a/internal/indexer/types/delegation_state.go
+++ b/internal/indexer/types/delegation_state.go
@@ -9,8 +9,9 @@ const (
 	StateActive       DelegationState = "ACTIVE"
 	StateUnbonding    DelegationState = "UNBONDING"
 	StateWithdrawable DelegationState = "WITHDRAWABLE"
-	StateWithdrawn    DelegationState = "WITHDRAWN"
 	StateSlashed      DelegationState = "SLASHED"
+	StateWithdrawn    DelegationState = "WITHDRAWN"
+	StateExpanded     DelegationState = "EXPANDED"
 )
 
 func (s DelegationState) String() string {

--- a/internal/v2/types/delegation_states.go
+++ b/internal/v2/types/delegation_states.go
@@ -31,6 +31,9 @@ const (
 	StateEarlyUnbondingWithdrawn         DelegationState = "EARLY_UNBONDING_WITHDRAWN"
 	StateTimelockSlashingWithdrawn       DelegationState = "TIMELOCK_SLASHING_WITHDRAWN"
 	StateEarlyUnbondingSlashingWithdrawn DelegationState = "EARLY_UNBONDING_SLASHING_WITHDRAWN"
+
+	// Expanded states
+	StateExpanded DelegationState = "EXPANDED"
 )
 
 // MapDelegationState consumes internal indexer states and maps them to the frontend-facing states
@@ -44,39 +47,59 @@ func MapDelegationState(state indexertypes.DelegationState, subState indexertype
 		return StateActive, nil
 	case indexertypes.StateSlashed:
 		return StateSlashed, nil
-
+	case indexertypes.StateExpanded:
+		return StateExpanded, nil
 	case indexertypes.StateUnbonding:
-		switch subState {
-		case indexertypes.SubStateTimelock:
-			return StateTimelockUnbonding, nil
-		case indexertypes.SubStateEarlyUnbonding:
-			return StateEarlyUnbonding, nil
-		}
-
+		return mapUnbondingState(subState)
 	case indexertypes.StateWithdrawable:
-		switch subState {
-		case indexertypes.SubStateTimelock:
-			return StateTimelockWithdrawable, nil
-		case indexertypes.SubStateEarlyUnbonding:
-			return StateEarlyUnbondingWithdrawable, nil
-		case indexertypes.SubStateTimelockSlashing:
-			return StateTimelockSlashingWithdrawable, nil
-		case indexertypes.SubStateEarlyUnbondingSlashing:
-			return StateEarlyUnbondingSlashingWithdrawable, nil
-		}
-
+		return mapWithdrawableState(subState)
 	case indexertypes.StateWithdrawn:
-		switch subState {
-		case indexertypes.SubStateTimelock:
-			return StateTimelockWithdrawn, nil
-		case indexertypes.SubStateEarlyUnbonding:
-			return StateEarlyUnbondingWithdrawn, nil
-		case indexertypes.SubStateTimelockSlashing:
-			return StateTimelockSlashingWithdrawn, nil
-		case indexertypes.SubStateEarlyUnbondingSlashing:
-			return StateEarlyUnbondingSlashingWithdrawn, nil
-		}
+		return mapWithdrawnState(subState)
 	}
 
 	return "", fmt.Errorf("invalid state/subState combination: state=%s, subState=%s", state, subState)
+}
+
+// mapUnbondingState maps unbonding states based on subState
+func mapUnbondingState(subState indexertypes.DelegationSubState) (DelegationState, error) {
+	switch subState {
+	case indexertypes.SubStateTimelock:
+		return StateTimelockUnbonding, nil
+	case indexertypes.SubStateEarlyUnbonding:
+		return StateEarlyUnbonding, nil
+	default:
+		return "", fmt.Errorf("invalid subState for StateUnbonding: %s", subState)
+	}
+}
+
+// mapWithdrawableState maps withdrawable states based on subState
+func mapWithdrawableState(subState indexertypes.DelegationSubState) (DelegationState, error) {
+	switch subState {
+	case indexertypes.SubStateTimelock:
+		return StateTimelockWithdrawable, nil
+	case indexertypes.SubStateEarlyUnbonding:
+		return StateEarlyUnbondingWithdrawable, nil
+	case indexertypes.SubStateTimelockSlashing:
+		return StateTimelockSlashingWithdrawable, nil
+	case indexertypes.SubStateEarlyUnbondingSlashing:
+		return StateEarlyUnbondingSlashingWithdrawable, nil
+	default:
+		return "", fmt.Errorf("invalid subState for StateWithdrawable: %s", subState)
+	}
+}
+
+// mapWithdrawnState maps withdrawn states based on subState
+func mapWithdrawnState(subState indexertypes.DelegationSubState) (DelegationState, error) {
+	switch subState {
+	case indexertypes.SubStateTimelock:
+		return StateTimelockWithdrawn, nil
+	case indexertypes.SubStateEarlyUnbonding:
+		return StateEarlyUnbondingWithdrawn, nil
+	case indexertypes.SubStateTimelockSlashing:
+		return StateTimelockSlashingWithdrawn, nil
+	case indexertypes.SubStateEarlyUnbondingSlashing:
+		return StateEarlyUnbondingSlashingWithdrawn, nil
+	default:
+		return "", fmt.Errorf("invalid subState for StateWithdrawn: %s", subState)
+	}
 }


### PR DESCRIPTION
We already store the EXPANDED state for delegations in the database, but it is not currently exposed through the API.
This PR introduces the EXPANDED state to the API so the dApp can use it to display the appropriate UI.

Previously, expanded delegations were shown as UNBONDED, which is not a terminal state. In reality, however, an expanded delegation has reached its terminal state and no further actions can be taken on it.