### PR TITLE
fix: finality provider stats not showing any data due to missing

### DIFF
--- a/internal/indexer/db/client/finality_provider.go
+++ b/internal/indexer/db/client/finality_provider.go
@@ -16,20 +16,14 @@ func (indexerdbclient *IndexerDatabase) GetFinalityProviders(
 		indexerdbclient.DbName,
 	).Collection(indexerdbmodel.FinalityProviderDetailsCollection)
 
+	// default filter to fetch all finality providers if bsnID is nil
 	filter := bson.M{}
-	if bsnID != nil && *bsnID == "all" {
-		// When bsnID is "all", fetch all values without any filter
-		filter = bson.M{}
-	} else if bsnID != nil && *bsnID != "" {
-		filter["bsn_id"] = *bsnID
-	} else {
-		// When bsnID is nil or empty, fetch items that don't have bsn_id field or have empty string
-		// TODO: temporary solution until figure out the bsn_id for BABY chain
-		filter = bson.M{
-			"$or": []bson.M{
-				{"bsn_id": bson.M{"$exists": false}},
-				{"bsn_id": ""},
-			},
+	if bsnID != nil {
+		if *bsnID == "all" {
+			// When bsnID is "all", fetch all values without any filter
+			filter = bson.M{}
+		} else {
+			filter["bsn_id"] = *bsnID
 		}
 	}
 

--- a/internal/v2/service/stats.go
+++ b/internal/v2/service/stats.go
@@ -52,8 +52,10 @@ func (s *V2Service) GetOverallStats(
 		return nil, types.NewInternalServiceError(err)
 	}
 
-	// TODO: ideally this should not be fetched from the indexer db
-	finalityProviders, err := s.dbClients.IndexerDBClient.GetFinalityProviders(ctx, nil)
+	// We only care about the Babylon finality providers stats for now
+	finalityProviders, err := s.dbClients.IndexerDBClient.GetFinalityProviders(
+		ctx, &s.sharedService.ChainInfo.ChainID,
+	)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("error while fetching finality providers")
 		return nil, types.NewInternalServiceError(err)

--- a/internal/v2/service/stats_test.go
+++ b/internal/v2/service/stats_test.go
@@ -24,6 +24,12 @@ func Test_GetOverallStats(t *testing.T) {
 	dbV1 := mocks.NewV1DBClient(t)
 	dbV2 := mocks.NewV2DBClient(t)
 	dbIndexer := mocks.NewIndexerDBClient(t)
+
+	// Create a ChainInfo with a test ChainID
+	chainInfo := &types.ChainInfo{
+		ChainID: "test-chain-id",
+	}
+
 	s, err := New(&service.Service{
 		DbClients: &dbclients.DbClients{
 			SharedDBClient:  dbShared,
@@ -34,6 +40,7 @@ func Test_GetOverallStats(t *testing.T) {
 		Clients: &clients.Clients{
 			CoinMarketCap: cmc.NewClient(nil),
 		},
+		ChainInfo: chainInfo,
 	}, nil, nil)
 	require.NoError(t, err)
 
@@ -49,7 +56,7 @@ func Test_GetOverallStats(t *testing.T) {
 		// we pass zero value as 1st return value which is ok - we won't use its values anyway
 		dbV2.On("GetOverallStats", ctx).Return(&v2dbmodel.V2OverallStatsDocument{}, nil).Once()
 		err := errors.New("indexer err")
-		dbIndexer.On("GetFinalityProviders", ctx, (*string)(nil)).Return(nil, err).Once()
+		dbIndexer.On("GetFinalityProviders", ctx, &chainInfo.ChainID).Return(nil, err).Once()
 
 		resp, respErr := s.GetOverallStats(ctx)
 		assert.Equal(t, types.NewInternalServiceError(err), respErr)
@@ -59,7 +66,7 @@ func Test_GetOverallStats(t *testing.T) {
 		// we pass zero value as 1st return value which is ok - we won't use its values anyway
 		dbV2.On("GetOverallStats", ctx).Return(&v2dbmodel.V2OverallStatsDocument{}, nil).Once()
 		// note that first return value (finality providers) is nil which is ok (iteration over nil slice is valid)
-		dbIndexer.On("GetFinalityProviders", ctx, (*string)(nil)).Return(nil, nil).Once()
+		dbIndexer.On("GetFinalityProviders", ctx, &chainInfo.ChainID).Return(nil, nil).Once()
 		err := errors.New("v1 err")
 		dbV1.On("GetOverallStats", ctx).Return(nil, err).Once()
 
@@ -71,7 +78,7 @@ func Test_GetOverallStats(t *testing.T) {
 		dbV2.On("GetOverallStats", ctx).Return(&v2dbmodel.V2OverallStatsDocument{
 			ActiveTvl: 777, // here is important to pass non-zero tvl so it triggers staking BTC calculation
 		}, nil).Once()
-		dbIndexer.On("GetFinalityProviders", ctx, (*string)(nil)).Return(nil, nil).Once()
+		dbIndexer.On("GetFinalityProviders", ctx, &chainInfo.ChainID).Return(nil, nil).Once()
 		dbV1.On("GetOverallStats", ctx).Return(&v1dbmodel.OverallStatsDocument{}, nil).Once()
 		err := errors.New("db err")
 		// this error shouldn't trigger error in GetOverallStats method


### PR DESCRIPTION
Fix the bug caused by previous change where FP db query is expecting passing in the babylon chain bsnId for fetching the FPs

This is what's returned after fix on devnet

<img width="369" height="206" alt="image" src="https://github.com/user-attachments/assets/566655e1-3e64-463f-80b8-9b1273e930f2" />
