### PR TITLE
chore: Bump CI workflows and pin to SHA hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,7 @@ permissions:
 
 jobs:
   lint_test:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
-=======
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@cfbd5e4db5e575edf77a160fe533918c4f3a4498 # v0.13.2
->>>>>>> Stashed changes
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
     with:
      go-version: 1.24.3
      go-lint-version: v2.4.0
@@ -26,11 +22,7 @@ jobs:
      gosec-args: "-no-fail ./..."
      
   docker_pipeline:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     secrets: inherit
     permissions:
       security-events: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ permissions:
 
 jobs:
   lint_test:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@cfbd5e4db5e575edf77a160fe533918c4f3a4498 # v0.13.2
+>>>>>>> Stashed changes
     with:
      go-version: 1.24.3
      go-lint-version: v2.4.0
@@ -22,7 +26,11 @@ jobs:
      gosec-args: "-no-fail ./..."
      
   docker_pipeline:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     secrets: inherit
     permissions:
       security-events: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,7 @@ permissions:
 
 jobs:
   lint_test:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     with:
      go-version: '1.24.3'
      go-lint-version: v2.4.0
@@ -27,11 +23,7 @@ jobs:
      
   docker_pipeline:
     # needs: ["lint_test"]
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     secrets: inherit
     permissions:
       security-events: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,11 @@ permissions:
 
 jobs:
   lint_test:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     with:
      go-version: '1.24.3'
      go-lint-version: v2.4.0
@@ -23,7 +27,11 @@ jobs:
      
   docker_pipeline:
     # needs: ["lint_test"]
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     secrets: inherit
     permissions:
       security-events: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   call-reusable-release:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_github_release.yml@v0.13.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_github_release.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
     with:
       tag: ${{ inputs.tag }}
       description: ${{ inputs.description }}


### PR DESCRIPTION
This PR bumps all the reusable git workflows to the latest available version, and pins them all to commit hashes instead of git tags for additional security.