### PR TITLE
fix: use DelegationState enum type for v1 delegation response

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -987,7 +987,8 @@ const docTemplate = `{
         "map_string_float64": {
             "type": "object",
             "additionalProperties": {
-                "type": "number"
+                "type": "number",
+                "format": "float64"
             }
         },
         "map_string_string": {
@@ -995,6 +996,29 @@ const docTemplate = `{
             "additionalProperties": {
                 "type": "string"
             }
+        },
+        "types.DelegationState": {
+            "type": "string",
+            "enum": [
+                "active",
+                "unbonding_requested",
+                "unbonding",
+                "unbonded",
+                "withdrawable",
+                "withdrawn",
+                "transitioned",
+                "slashed"
+            ],
+            "x-enum-varnames": [
+                "Active",
+                "UnbondingRequested",
+                "Unbonding",
+                "Unbonded",
+                "Withdrawable",
+                "Withdrawn",
+                "Transitioned",
+                "Slashed"
+            ]
         },
         "types.ErrorCode": {
             "type": "string",
@@ -1104,7 +1128,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "state": {
-                    "type": "string"
+                    "$ref": "#/definitions/types.DelegationState"
                 },
                 "unbonding_tx": {
                     "$ref": "#/definitions/v1service.TransactionPublic"
@@ -1328,6 +1352,9 @@ const docTemplate = `{
                 },
                 "state": {
                     "$ref": "#/definitions/v2types.DelegationState"
+                },
+                "withdrawal_info": {
+                    "$ref": "#/definitions/v2service.WithdrawalInfo"
                 }
             }
         },
@@ -1570,6 +1597,14 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "unbonding_slashing_tx_hex": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2service.WithdrawalInfo": {
+            "type": "object",
+            "properties": {
+                "tx_hash": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -979,7 +979,8 @@
         "map_string_float64": {
             "type": "object",
             "additionalProperties": {
-                "type": "number"
+                "type": "number",
+                "format": "float64"
             }
         },
         "map_string_string": {
@@ -987,6 +988,29 @@
             "additionalProperties": {
                 "type": "string"
             }
+        },
+        "types.DelegationState": {
+            "type": "string",
+            "enum": [
+                "active",
+                "unbonding_requested",
+                "unbonding",
+                "unbonded",
+                "withdrawable",
+                "withdrawn",
+                "transitioned",
+                "slashed"
+            ],
+            "x-enum-varnames": [
+                "Active",
+                "UnbondingRequested",
+                "Unbonding",
+                "Unbonded",
+                "Withdrawable",
+                "Withdrawn",
+                "Transitioned",
+                "Slashed"
+            ]
         },
         "types.ErrorCode": {
             "type": "string",
@@ -1096,7 +1120,7 @@
                     "type": "integer"
                 },
                 "state": {
-                    "type": "string"
+                    "$ref": "#/definitions/types.DelegationState"
                 },
                 "unbonding_tx": {
                     "$ref": "#/definitions/v1service.TransactionPublic"
@@ -1320,6 +1344,9 @@
                 },
                 "state": {
                     "$ref": "#/definitions/v2types.DelegationState"
+                },
+                "withdrawal_info": {
+                    "$ref": "#/definitions/v2service.WithdrawalInfo"
                 }
             }
         },
@@ -1562,6 +1589,14 @@
                     "type": "integer"
                 },
                 "unbonding_slashing_tx_hex": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2service.WithdrawalInfo": {
+            "type": "object",
+            "properties": {
+                "tx_hash": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -168,12 +168,33 @@ definitions:
     type: object
   map_string_float64:
     additionalProperties:
+      format: float64
       type: number
     type: object
   map_string_string:
     additionalProperties:
       type: string
     type: object
+  types.DelegationState:
+    enum:
+    - active
+    - unbonding_requested
+    - unbonding
+    - unbonded
+    - withdrawable
+    - withdrawn
+    - transitioned
+    - slashed
+    type: string
+    x-enum-varnames:
+    - Active
+    - UnbondingRequested
+    - Unbonding
+    - Unbonded
+    - Withdrawable
+    - Withdrawn
+    - Transitioned
+    - Slashed
   types.ErrorCode:
     enum:
     - INTERNAL_SERVICE_ERROR
@@ -250,7 +271,7 @@ definitions:
       staking_value:
         type: integer
       state:
-        type: string
+        $ref: '#/definitions/types.DelegationState'
       unbonding_tx:
         $ref: '#/definitions/v1service.TransactionPublic'
     type: object
@@ -397,6 +418,8 @@ definitions:
         type: string
       state:
         $ref: '#/definitions/v2types.DelegationState'
+      withdrawal_info:
+        $ref: '#/definitions/v2service.WithdrawalInfo'
     type: object
   v2service.DelegationStaking:
     properties:
@@ -560,6 +583,11 @@ definitions:
       spending_height:
         type: integer
       unbonding_slashing_tx_hex:
+        type: string
+    type: object
+  v2service.WithdrawalInfo:
+    properties:
+      tx_hash:
         type: string
     type: object
   v2service.apr:

--- a/internal/v1/service/delegation.go
+++ b/internal/v1/service/delegation.go
@@ -24,16 +24,16 @@ type TransactionPublic struct {
 }
 
 type DelegationPublic struct {
-	StakingTxHashHex        string             `json:"staking_tx_hash_hex"`
-	StakerPkHex             string             `json:"staker_pk_hex"`
-	FinalityProviderPkHex   string             `json:"finality_provider_pk_hex"`
-	State                   string             `json:"state"`
-	StakingValue            uint64             `json:"staking_value"`
-	StakingTx               *TransactionPublic `json:"staking_tx"`
-	UnbondingTx             *TransactionPublic `json:"unbonding_tx,omitempty"`
-	IsOverflow              bool               `json:"is_overflow"`
-	IsEligibleForTransition bool               `json:"is_eligible_for_transition"`
-	IsSlashed               bool               `json:"is_slashed"`
+	StakingTxHashHex        string                `json:"staking_tx_hash_hex"`
+	StakerPkHex             string                `json:"staker_pk_hex"`
+	FinalityProviderPkHex   string                `json:"finality_provider_pk_hex"`
+	State                   types.DelegationState `json:"state"`
+	StakingValue            uint64                `json:"staking_value"`
+	StakingTx               *TransactionPublic    `json:"staking_tx"`
+	UnbondingTx             *TransactionPublic    `json:"unbonding_tx,omitempty"`
+	IsOverflow              bool                  `json:"is_overflow"`
+	IsEligibleForTransition bool                  `json:"is_eligible_for_transition"`
+	IsSlashed               bool                  `json:"is_slashed"`
 }
 
 func (s *V1Service) DelegationsByStakerPk(
@@ -203,7 +203,7 @@ func (s *V1Service) FromDelegationDocument(
 		StakerPkHex:           d.StakerPkHex,
 		FinalityProviderPkHex: d.FinalityProviderPkHex,
 		StakingValue:          d.StakingValue,
-		State:                 d.State.ToString(),
+		State:                 d.State,
 		StakingTx: &TransactionPublic{
 			TxHex:          d.StakingTx.TxHex,
 			OutputIndex:    d.StakingTx.OutputIndex,


### PR DESCRIPTION
part of https://github.com/babylonlabs-io/staking-api-service/issues/298

- Changed `State` field in `v1service.DelegationPublic` from `string` to `types.DelegationState`
- Regenerated swagger docs