### PR TITLE
test: add for v2 apr endpoint

### DIFF
--- a/internal/v2/service/stats_test.go
+++ b/internal/v2/service/stats_test.go
@@ -155,7 +155,7 @@ func Test_calculateUserCoStakingAPR(t *testing.T) {
 			50000,
 			0.5,
 		)
-		assert.Equal(t, float64(0), apr)
+		assert.Zero(t, apr)
 	})
 
 	t.Run("zero global score returns zero", func(t *testing.T) {
@@ -168,7 +168,7 @@ func Test_calculateUserCoStakingAPR(t *testing.T) {
 			50000,
 			0.5,
 		)
-		assert.Equal(t, float64(0), apr)
+		assert.Zero(t, apr)
 	})
 
 	t.Run("calculates correctly with valid inputs", func(t *testing.T) {
@@ -181,7 +181,7 @@ func Test_calculateUserCoStakingAPR(t *testing.T) {
 			50000,
 			0.5,
 		)
-		assert.Greater(t, apr, float64(0))
+		assert.Positive(t, apr)
 	})
 
 	t.Run("no BABY staked returns zero co-staking APR", func(t *testing.T) {
@@ -194,7 +194,7 @@ func Test_calculateUserCoStakingAPR(t *testing.T) {
 			50000,
 			0.5,
 		)
-		assert.Equal(t, float64(0), apr)
+		assert.Zero(t, apr)
 	})
 }
 
@@ -211,7 +211,7 @@ func Test_calculateBoostCoStakingAPR(t *testing.T) {
 			50000,
 			0.5,
 		)
-		assert.Equal(t, float64(0), apr)
+		assert.Zero(t, apr)
 	})
 
 	t.Run("zero global score returns zero", func(t *testing.T) {
@@ -224,7 +224,7 @@ func Test_calculateBoostCoStakingAPR(t *testing.T) {
 			50000,
 			0.5,
 		)
-		assert.Equal(t, float64(0), apr)
+		assert.Zero(t, apr)
 	})
 
 	t.Run("boost APR >= current APR", func(t *testing.T) {
@@ -232,9 +232,9 @@ func Test_calculateBoostCoStakingAPR(t *testing.T) {
 		ubbnStaked := int64(50000000)
 		globalTotalScore := int64(1000000000)
 		scoreRatio := int64(1000)
-		totalCoStakingRewardSupply := float64(1000000)
-		btcPrice := float64(50000)
-		babyPrice := float64(0.5)
+		totalCoStakingRewardSupply := 1000000.0
+		btcPrice := 50000.0
+		babyPrice := 0.5
 
 		currentAPR := s.calculateUserCoStakingAPR(
 			satoshisStaked, ubbnStaked, globalTotalScore, scoreRatio,

--- a/tests/api/v2_test.go
+++ b/tests/api/v2_test.go
@@ -133,3 +133,52 @@ func TestV2_StakerStats(t *testing.T) {
 
 	checkCases(t, cases)
 }
+
+func TestV2_APR(t *testing.T) {
+	cases := []testcase{
+		{
+			testName:         "invalid satoshis_staked - non integer",
+			endpoint:         "/v2/apr?satoshis_staked=abc",
+			expectedHttpCode: http.StatusBadRequest,
+			expectedContents: `{"errorCode":"BAD_REQUEST","message":"invalid satoshis_staked: must be a valid integer"}`,
+		},
+		{
+			testName:         "invalid ubbn_staked - non integer",
+			endpoint:         "/v2/apr?ubbn_staked=xyz",
+			expectedHttpCode: http.StatusBadRequest,
+			expectedContents: `{"errorCode":"BAD_REQUEST","message":"invalid ubbn_staked: must be a valid integer"}`,
+		},
+		{
+			testName:         "negative satoshis_staked",
+			endpoint:         "/v2/apr?satoshis_staked=-100",
+			expectedHttpCode: http.StatusBadRequest,
+			expectedContents: `{"errorCode":"BAD_REQUEST","message":"invalid satoshis_staked: must be non-negative"}`,
+		},
+		{
+			testName:         "negative ubbn_staked",
+			endpoint:         "/v2/apr?ubbn_staked=-100",
+			expectedHttpCode: http.StatusBadRequest,
+			expectedContents: `{"errorCode":"BAD_REQUEST","message":"invalid ubbn_staked: must be non-negative"}`,
+		},
+		{
+			testName:         "invalid both params",
+			endpoint:         "/v2/apr?satoshis_staked=invalid&ubbn_staked=invalid",
+			expectedHttpCode: http.StatusBadRequest,
+			expectedContents: `{"errorCode":"BAD_REQUEST","message":"invalid satoshis_staked: must be a valid integer"}`,
+		},
+		{
+			testName:         "default params - service error due to nil bbn client",
+			endpoint:         "/v2/apr",
+			expectedHttpCode: http.StatusInternalServerError,
+			expectedContents: `{"errorCode":"INTERNAL_SERVICE_ERROR","message":"Internal service error"}`,
+		},
+		{
+			testName:         "valid params - service error due to nil bbn client",
+			endpoint:         "/v2/apr?satoshis_staked=1000000&ubbn_staked=5000000",
+			expectedHttpCode: http.StatusInternalServerError,
+			expectedContents: `{"errorCode":"INTERNAL_SERVICE_ERROR","message":"Internal service error"}`,
+		},
+	}
+
+	checkCases(t, cases)
+}


### PR DESCRIPTION
Adds unit and e2e tests for the `/v2/apr` endpoint and APR calculation functions

resolves: https://github.com/babylonlabs-io/staking-api-service/issues/420