### PR TITLE
refactor: use dynamic values instead of constants in stats

### DIFF
--- a/internal/v2/service/stats.go
+++ b/internal/v2/service/stats.go
@@ -342,9 +342,11 @@ func (s *V2Service) calculateBabyStakingAPR(ctx context.Context) (float64, error
 	// 0.02
 	babyInflationRate := cosmosMath.LegacyNewDecWithPrec(2, 2)
 
+	//nolint: gocritic
 	// totalBabyRewardsSupply = totalRewardsSupply * babyInflationRate
 	totalBabyRewardsSupply := totalRewardsSupply.Amount.ToLegacyDec().Mul(babyInflationRate)
 	totalBabyStaked := stakingPool.BondedTokens.ToLegacyDec()
+	//nolint: gocritic
 	// apr = totalBabyRewardsSupply / totalBabyStaked
 	apr := totalBabyRewardsSupply.Quo(totalBabyStaked)
 


### PR DESCRIPTION
Replaced hardcoded ratio with dynamic values fetched from the node using the formula:
```
(1 - btc_staking_portion - fp_portion) × costaking_portion
```

This reuses the existing `getCostakingRewardSupply()` which already implements this calculation with 1-minute caching

- `calculateCoStakingAPR` now accepts pre-computed `totalCoStakingRewardSupply` instead of calculating with hardcoded constants
- `GetOverallStats` fetches `totalCoStakingRewardSupply` in parallel with other data
- removed unused `getAnnualProvisions()`