### PR TITLE
chore: implement pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# Requirements:
+### MacOS: `brew install pre-commit`
+### Linux: `pip3 install pre-commit`
+
+# NOTE: The first run will take some time as it will download all the hooks.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Prevent committing to main directly
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
+
+      # Catch merge conflict markers
+      - id: check-merge-conflict
+
+      # Validate file formats
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+      - id: check-json
+      - id: check-toml
+
+      # Detect private keys
+      - id: detect-private-key
+
+      # Clean up whitespace issues
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+
+      # Prevent debug statements & credentials
+      - id: check-case-conflict          # Case-insensitive filesystem issues
+      - id: check-executables-have-shebangs
+
+# For allowing secrets to be committed, add this comment: # gitleaks:allow
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,9 @@ repos:
       - id: mixed-line-ending
         args: ['--fix=lf']
 
-      # Prevent debug statements & credentials
+      # Detect filesystem and executable issues
       - id: check-case-conflict          # Case-insensitive filesystem issues
-      - id: check-executables-have-shebangs
+      - id: check-executables-have-shebangs  # Ensure executables have a valid shebang
 
 # For allowing secrets to be committed, add this comment: # gitleaks:allow
   - repo: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
This will prevent accidental commits with secrets and enforce good practices before the bad ones reach the remote code.