### PR TITLE
fix(ci): add permissions and bump docker pipeline to v0.16.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,12 @@ jobs:
      gosec-args: "-no-fail ./..."
      
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
-    secrets: inherit
     permissions:
-      security-events: write
-      packages: read
+      contents: read         # Required by reusable workflow
+      id-token: write        # Required for AWS OIDC
+      security-events: write # Required for Trivy SARIF uploads
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@d2299e834fcbaca4bf2db043a2939798043d5951 # v0.16.1
+    secrets: inherit
     with:
       publish: false
       dockerfile: ./contrib/images/staking-api-service/Dockerfile


### PR DESCRIPTION
Add job-level permissions for docker_pipeline job.

Required by reusable_docker_pipeline.yml:
- contents: read - checkout access
- id-token: write - AWS OIDC authentication
- security-events: write - Trivy SARIF uploads