### PR TITLE
fix(ordinals): force IPv4 for the ordinals HTTP client

### DIFF
--- a/contrib/images/staking-api-service/Dockerfile
+++ b/contrib/images/staking-api-service/Dockerfile
@@ -34,7 +34,7 @@ ARG VERSION="HEAD"
 RUN addgroup --gid 1138 -S staking-api-service && adduser --uid 1138 -S staking-api-service -G staking-api-service
 RUN apk add --no-cache \
     bash=5.3.3-r1 \
-    curl=8.19.0-r0 \
+    curl=8.20.0-r0 \
     jq=1.8.1-r0
 
 LABEL org.opencontainers.image.source="https://github.com/babylonlabs-io/staking-api-service:${VERSION}"

--- a/internal/shared/http/clients/ordinals/ordinals.go
+++ b/internal/shared/http/clients/ordinals/ordinals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -29,7 +30,18 @@ func New(config *config.OrdinalsConfig) *Ordinals {
 	if config == nil {
 		return nil
 	}
-	httpClient := &http.Client{}
+	// Force IPv4 for the ordinals host. It is Cloudflare-proxied, so DNS
+	// returns both A and AAAA (Cloudflare's own dual-stack), but the pods run
+	// on IPv4-only nodes with no IPv6 route. The default dialer picks the AAAA
+	// first, hits "network unreachable", and does not fall back — every call
+	// fails. Dialing "tcp4" skips the dead IPv6 path. Clone the default
+	// transport so proxy/TLS/idle-conn defaults are preserved.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	transport.DialContext = func(ctx context.Context, _, addr string) (net.Conn, error) {
+		return dialer.DialContext(ctx, "tcp4", addr)
+	}
+	httpClient := &http.Client{Transport: transport}
 	headers := map[string]string{
 		"Content-Type": "application/json",
 		"Accept":       "application/json",


### PR DESCRIPTION
## Problem

Mainnet `/v1/ordinals/verify-utxos` has been **~100% failing for 30+ days** (also seen on testnet). The staking-api ordinals client can't connect to `ord.babylonlabs.io` — every call errors with a transport failure (`failed to send request`), surfaced as 500.

## Root cause (infra + client)

`ord.babylonlabs.io` is **Cloudflare-proxied**, so DNS returns **both A and AAAA** — Cloudflare's own dual-stack anycast (`104.18.x` + `2606:4700::`). The staking-api pods run on **IPv4-only nodes with no IPv6 route**. The default Go dialer picks the **AAAA first**, hits `network unreachable` instantly, and does **not** fall back to IPv4 — so every request dies. (curl/browsers fall back and work; this client doesn't.)

Verified in-cluster: dialing IPv4 → HTTP 200; dialing IPv6 → `network unreachable`.

## Fix

Scope: the **ordinals client only**. Clone `http.DefaultTransport` (keep proxy/TLS/idle-conn defaults) and override `DialContext` to dial `tcp4`, skipping the dead IPv6 path. Builds + gofmt clean; other clients unchanged.

## Notes

- App-side fix (deploy only restarts staking-api pods, no node recycle). Infra alternative = disable the dangling IPv6 on the nodes; either resolves it.
- DevOps added dependency-health alerts (flux-gitops#144) so a 100%-down low-volume dependency pages next time.